### PR TITLE
Added missing DOCTYPE and wp_head call

### DIFF
--- a/inc/template-head-generic.php
+++ b/inc/template-head-generic.php
@@ -13,3 +13,4 @@
   window.rsConf = { general: { usePost: true } }
 </script>
 <script src="//cdn1.readspeaker.com/script/<?php echo get_option('theme_read_speaker_id'); ?>/webReader/webReader.js?pids=wr" type="text/javascript"></script>
+<?php wp_head(); ?>

--- a/index.php
+++ b/index.php
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="fi">
   <head>
     <?php require get_template_directory() . '/inc/template-head-generic.php'; ?>


### PR DESCRIPTION
GA Pro plugin Google Analytics script block shows up now correctly and missing DOCTYPE added